### PR TITLE
tools: fix dumping of shaders

### DIFF
--- a/tools/dump_cmdstream.py
+++ b/tools/dump_cmdstream.py
@@ -175,10 +175,17 @@ def dump_buf(f, name, data):
 
 def dump_shader(f, name, states, start, end):
     '''Dump binary shader code to disk'''
-    if not start in states:
+    dump = False
+
+    for x in range(start, end, 4):
+        if x in states:
+            dump = True
+            pos = x
+            break;
+
+    if not dump:
         return # No shader detected
     # extract code from consecutive addresses
-    pos = start
     code = []
     while pos < end and (pos in states):
         code.append(states[pos])


### PR DESCRIPTION
It can happen that shader binary does not start at offset 0 of defined
state ranges. Change dump_shader to look if there is at least on state
in the range from start to end. This fixes dumping of the following
galcore command stream.

0x081837e8, /* LOAD_STATE (1) Base: 0x0DFA0 Size: 24 Fixp: 0 */
0x00811009, /*   [0DFA0] SH.INST_MEM[2024] := 0x811009 */
0x00000000, /*   [0DFA4] SH.INST_MEM[2025] := 0x0 */
0x00000000, /*   [0DFA8] SH.INST_MEM[2026] := 0x0 */
0x20000008, /*   [0DFAC] SH.INST_MEM[2027] := 0x20000008 */
0x00811001, /*   [0DFB0] SH.INST_MEM[2028] := 0x811001 */
0x00001800, /*   [0DFB4] SH.INST_MEM[2029] := 0x1800 */
0x00000000, /*   [0DFB8] SH.INST_MEM[2030] := 0x0 */
0x20554008, /*   [0DFBC] SH.INST_MEM[2031] := 0x20554008 */
0x01021001, /*   [0DFC0] SH.INST_MEM[2032] := 0x1021001 */
0x00001800, /*   [0DFC4] SH.INST_MEM[2033] := 0x1800 */
0x00000000, /*   [0DFC8] SH.INST_MEM[2034] := 0x0 */
0x20154008, /*   [0DFCC] SH.INST_MEM[2035] := 0x20154008 */
0x06021001, /*   [0DFD0] SH.INST_MEM[2036] := 0x6021001 */
0x00001800, /*   [0DFD4] SH.INST_MEM[2037] := 0x1800 */
0x00000000, /*   [0DFD8] SH.INST_MEM[2038] := 0x0 */
0x20554008, /*   [0DFDC] SH.INST_MEM[2039] := 0x20554008 */
0x00821009, /*   [0DFE0] SH.INST_MEM[2040] := 0x821009 */
0x00000000, /*   [0DFE4] SH.INST_MEM[2041] := 0x0 */
0x00000000, /*   [0DFE8] SH.INST_MEM[2042] := 0x0 */
0x20000008, /*   [0DFEC] SH.INST_MEM[2043] := 0x20000008 */
0x07811003, /*   [0DFF0] SH.INST_MEM[2044] := 0x7811003 */
0x39002800, /*   [0DFF4] SH.INST_MEM[2045] := 0x39002800 */
0x01540040, /*   [0DFF8] SH.INST_MEM[2046] := 0x1540040 */
0x00000002, /*   [0DFFC] SH.INST_MEM[2047] := 0x2 */
0x00000000, /* PAD */

Signed-off-by: Christian Gmeiner <christian.gmeiner@gmail.com>