### PR TITLE
rnndb: Add new feature bits.

### DIFF
--- a/rnndb/common.xml
+++ b/rnndb/common.xml
@@ -209,6 +209,7 @@ xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
         <bitfield pos="22" name="LINEAR_TEXTURE_SUPPORT"/>
         <bitfield pos="23" name="HALTI0" brief="Various features related to texturing and vertex processing">
             <doc>
+                - Texture swizzle
                 - Anisotropic texture filtering
                 - 3D texture support
                 - Texture array support
@@ -298,7 +299,7 @@ xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
         <bitfield pos="24" name="UNK24"/>
         <bitfield pos="25" name="UNK25"/>
         <bitfield pos="26" name="NEW_HZ"/>
-        <bitfield pos="27" name="UNK27"/>
+        <bitfield pos="27" name="PE_DITHER_FIX"/>
         <bitfield pos="28" name="UNK28"/>
         <bitfield pos="29" name="SH_ENHANCEMENTS3"/>
         <bitfield pos="30" name="UNK30"/>
@@ -338,7 +339,7 @@ xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
                 - FE reset vertex id
             </doc>
         </bitfield>
-        <bitfield pos="17" name="UNK17"/>
+        <bitfield pos="17" name="2D_MIRROR_EXTENSION"/>
         <bitfield pos="18" name="SMALL_MSAA"/>
         <bitfield pos="19" name="UNK19"/>
         <bitfield pos="20" name="NEW_RA"/>

--- a/src/etnaviv/cmdstream.xml.h
+++ b/src/etnaviv/cmdstream.xml.h
@@ -8,9 +8,9 @@ http://0x04.net/cgit/index.cgi/rules-ng-ng
 git clone git://0x04.net/rules-ng-ng
 
 The rules-ng-ng source files this header was generated from are:
-- cmdstream.xml (  14313 bytes, from 2017-04-14 21:49:11)
-- copyright.xml (   1597 bytes, from 2017-04-14 21:48:20)
-- common.xml    (  23473 bytes, from 2017-04-14 21:49:11)
+- cmdstream.xml (  14313 bytes, from 2017-05-10 06:17:24)
+- copyright.xml (   1597 bytes, from 2017-05-10 06:17:24)
+- common.xml    (  23529 bytes, from 2017-05-10 06:23:17)
 
 Copyright (C) 2012-2017 by the following authors:
 - Wladimir J. van der Laan <laanwj@gmail.com>

--- a/src/etnaviv/common.xml.h
+++ b/src/etnaviv/common.xml.h
@@ -8,13 +8,13 @@ http://0x04.net/cgit/index.cgi/rules-ng-ng
 git clone git://0x04.net/rules-ng-ng
 
 The rules-ng-ng source files this header was generated from are:
-- state.xml     (  19930 bytes, from 2017-04-14 21:49:11)
-- common.xml    (  23473 bytes, from 2017-04-14 21:49:11)
-- state_hi.xml  (  26403 bytes, from 2017-04-14 21:49:11)
-- copyright.xml (   1597 bytes, from 2017-04-14 21:48:20)
-- state_2d.xml  (  51552 bytes, from 2017-04-14 21:48:20)
-- state_3d.xml  (  66964 bytes, from 2017-04-14 21:49:11)
-- state_vg.xml  (   5975 bytes, from 2017-04-14 21:48:20)
+- state.xml     (  19930 bytes, from 2017-05-10 06:17:24)
+- common.xml    (  23529 bytes, from 2017-05-10 06:23:17)
+- state_hi.xml  (  26403 bytes, from 2017-05-10 06:17:24)
+- copyright.xml (   1597 bytes, from 2017-05-10 06:17:24)
+- state_2d.xml  (  51552 bytes, from 2017-05-10 06:17:24)
+- state_3d.xml  (  66964 bytes, from 2017-05-10 06:17:24)
+- state_vg.xml  (   5975 bytes, from 2017-05-10 06:17:24)
 
 Copyright (C) 2012-2017 by the following authors:
 - Wladimir J. van der Laan <laanwj@gmail.com>
@@ -247,7 +247,7 @@ DEALINGS IN THE SOFTWARE.
 #define chipMinorFeatures3_UNK24				0x01000000
 #define chipMinorFeatures3_UNK25				0x02000000
 #define chipMinorFeatures3_NEW_HZ				0x04000000
-#define chipMinorFeatures3_UNK27				0x08000000
+#define chipMinorFeatures3_PE_DITHER_FIX			0x08000000
 #define chipMinorFeatures3_UNK28				0x10000000
 #define chipMinorFeatures3_SH_ENHANCEMENTS3			0x20000000
 #define chipMinorFeatures3_UNK30				0x40000000
@@ -269,7 +269,7 @@ DEALINGS IN THE SOFTWARE.
 #define chipMinorFeatures4_UNK14				0x00004000
 #define chipMinorFeatures4_UNK15				0x00008000
 #define chipMinorFeatures4_HALTI2				0x00010000
-#define chipMinorFeatures4_UNK17				0x00020000
+#define chipMinorFeatures4_2D_MIRROR_EXTENSION			0x00020000
 #define chipMinorFeatures4_SMALL_MSAA				0x00040000
 #define chipMinorFeatures4_UNK19				0x00080000
 #define chipMinorFeatures4_NEW_RA				0x00100000

--- a/src/etnaviv/isa.xml.h
+++ b/src/etnaviv/isa.xml.h
@@ -8,8 +8,8 @@ http://0x04.net/cgit/index.cgi/rules-ng-ng
 git clone git://0x04.net/rules-ng-ng
 
 The rules-ng-ng source files this header was generated from are:
-- isa.xml       (  34392 bytes, from 2017-04-14 21:49:48)
-- copyright.xml (   1597 bytes, from 2017-04-14 21:48:20)
+- isa.xml       (  34392 bytes, from 2017-05-10 06:17:24)
+- copyright.xml (   1597 bytes, from 2017-05-10 06:17:24)
 
 Copyright (C) 2012-2017 by the following authors:
 - Wladimir J. van der Laan <laanwj@gmail.com>

--- a/src/etnaviv/state.xml.h
+++ b/src/etnaviv/state.xml.h
@@ -8,13 +8,13 @@ http://0x04.net/cgit/index.cgi/rules-ng-ng
 git clone git://0x04.net/rules-ng-ng
 
 The rules-ng-ng source files this header was generated from are:
-- state.xml     (  19930 bytes, from 2017-04-14 21:49:11)
-- common.xml    (  23473 bytes, from 2017-04-14 21:49:11)
-- state_hi.xml  (  26403 bytes, from 2017-04-14 21:49:11)
-- copyright.xml (   1597 bytes, from 2017-04-14 21:48:20)
-- state_2d.xml  (  51552 bytes, from 2017-04-14 21:48:20)
-- state_3d.xml  (  66964 bytes, from 2017-04-14 21:49:11)
-- state_vg.xml  (   5975 bytes, from 2017-04-14 21:48:20)
+- state.xml     (  19930 bytes, from 2017-05-10 06:17:24)
+- common.xml    (  23529 bytes, from 2017-05-10 06:23:17)
+- state_hi.xml  (  26403 bytes, from 2017-05-10 06:17:24)
+- copyright.xml (   1597 bytes, from 2017-05-10 06:17:24)
+- state_2d.xml  (  51552 bytes, from 2017-05-10 06:17:24)
+- state_3d.xml  (  66964 bytes, from 2017-05-10 06:17:24)
+- state_vg.xml  (   5975 bytes, from 2017-05-10 06:17:24)
 
 Copyright (C) 2012-2017 by the following authors:
 - Wladimir J. van der Laan <laanwj@gmail.com>

--- a/src/etnaviv/state_2d.xml.h
+++ b/src/etnaviv/state_2d.xml.h
@@ -8,13 +8,13 @@ http://0x04.net/cgit/index.cgi/rules-ng-ng
 git clone git://0x04.net/rules-ng-ng
 
 The rules-ng-ng source files this header was generated from are:
-- state.xml     (  19930 bytes, from 2017-04-14 21:49:11)
-- common.xml    (  23473 bytes, from 2017-04-14 21:49:11)
-- state_hi.xml  (  26403 bytes, from 2017-04-14 21:49:11)
-- copyright.xml (   1597 bytes, from 2017-04-14 21:48:20)
-- state_2d.xml  (  51552 bytes, from 2017-04-14 21:48:20)
-- state_3d.xml  (  66964 bytes, from 2017-04-14 21:49:11)
-- state_vg.xml  (   5975 bytes, from 2017-04-14 21:48:20)
+- state.xml     (  19930 bytes, from 2017-05-10 06:17:24)
+- common.xml    (  23529 bytes, from 2017-05-10 06:23:17)
+- state_hi.xml  (  26403 bytes, from 2017-05-10 06:17:24)
+- copyright.xml (   1597 bytes, from 2017-05-10 06:17:24)
+- state_2d.xml  (  51552 bytes, from 2017-05-10 06:17:24)
+- state_3d.xml  (  66964 bytes, from 2017-05-10 06:17:24)
+- state_vg.xml  (   5975 bytes, from 2017-05-10 06:17:24)
 
 Copyright (C) 2012-2017 by the following authors:
 - Wladimir J. van der Laan <laanwj@gmail.com>

--- a/src/etnaviv/state_3d.xml.h
+++ b/src/etnaviv/state_3d.xml.h
@@ -8,13 +8,13 @@ http://0x04.net/cgit/index.cgi/rules-ng-ng
 git clone git://0x04.net/rules-ng-ng
 
 The rules-ng-ng source files this header was generated from are:
-- state.xml     (  19930 bytes, from 2017-04-14 21:49:11)
-- common.xml    (  23473 bytes, from 2017-04-14 21:49:11)
-- state_hi.xml  (  26403 bytes, from 2017-04-14 21:49:11)
-- copyright.xml (   1597 bytes, from 2017-04-14 21:48:20)
-- state_2d.xml  (  51552 bytes, from 2017-04-14 21:48:20)
-- state_3d.xml  (  66964 bytes, from 2017-04-14 21:49:11)
-- state_vg.xml  (   5975 bytes, from 2017-04-14 21:48:20)
+- state.xml     (  19930 bytes, from 2017-05-10 06:17:24)
+- common.xml    (  23529 bytes, from 2017-05-10 06:23:17)
+- state_hi.xml  (  26403 bytes, from 2017-05-10 06:17:24)
+- copyright.xml (   1597 bytes, from 2017-05-10 06:17:24)
+- state_2d.xml  (  51552 bytes, from 2017-05-10 06:17:24)
+- state_3d.xml  (  66964 bytes, from 2017-05-10 06:17:24)
+- state_vg.xml  (   5975 bytes, from 2017-05-10 06:17:24)
 
 Copyright (C) 2012-2017 by the following authors:
 - Wladimir J. van der Laan <laanwj@gmail.com>

--- a/src/etnaviv/state_hi.xml.h
+++ b/src/etnaviv/state_hi.xml.h
@@ -8,13 +8,13 @@ http://0x04.net/cgit/index.cgi/rules-ng-ng
 git clone git://0x04.net/rules-ng-ng
 
 The rules-ng-ng source files this header was generated from are:
-- state.xml     (  19930 bytes, from 2017-04-14 21:49:11)
-- common.xml    (  23473 bytes, from 2017-04-14 21:49:11)
-- state_hi.xml  (  26403 bytes, from 2017-04-14 21:49:11)
-- copyright.xml (   1597 bytes, from 2017-04-14 21:48:20)
-- state_2d.xml  (  51552 bytes, from 2017-04-14 21:48:20)
-- state_3d.xml  (  66964 bytes, from 2017-04-14 21:49:11)
-- state_vg.xml  (   5975 bytes, from 2017-04-14 21:48:20)
+- state.xml     (  19930 bytes, from 2017-05-10 06:17:24)
+- common.xml    (  23529 bytes, from 2017-05-10 06:23:17)
+- state_hi.xml  (  26403 bytes, from 2017-05-10 06:17:24)
+- copyright.xml (   1597 bytes, from 2017-05-10 06:17:24)
+- state_2d.xml  (  51552 bytes, from 2017-05-10 06:17:24)
+- state_3d.xml  (  66964 bytes, from 2017-05-10 06:17:24)
+- state_vg.xml  (   5975 bytes, from 2017-05-10 06:17:24)
 
 Copyright (C) 2012-2017 by the following authors:
 - Wladimir J. van der Laan <laanwj@gmail.com>

--- a/src/etnaviv/state_vg.xml.h
+++ b/src/etnaviv/state_vg.xml.h
@@ -8,13 +8,13 @@ http://0x04.net/cgit/index.cgi/rules-ng-ng
 git clone git://0x04.net/rules-ng-ng
 
 The rules-ng-ng source files this header was generated from are:
-- state.xml     (  19930 bytes, from 2017-04-14 21:49:11)
-- common.xml    (  23473 bytes, from 2017-04-14 21:49:11)
-- state_hi.xml  (  26403 bytes, from 2017-04-14 21:49:11)
-- copyright.xml (   1597 bytes, from 2017-04-14 21:48:20)
-- state_2d.xml  (  51552 bytes, from 2017-04-14 21:48:20)
-- state_3d.xml  (  66964 bytes, from 2017-04-14 21:49:11)
-- state_vg.xml  (   5975 bytes, from 2017-04-14 21:48:20)
+- state.xml     (  19930 bytes, from 2017-05-10 06:17:24)
+- common.xml    (  23529 bytes, from 2017-05-10 06:23:17)
+- state_hi.xml  (  26403 bytes, from 2017-05-10 06:17:24)
+- copyright.xml (   1597 bytes, from 2017-05-10 06:17:24)
+- state_2d.xml  (  51552 bytes, from 2017-05-10 06:17:24)
+- state_3d.xml  (  66964 bytes, from 2017-05-10 06:17:24)
+- state_vg.xml  (   5975 bytes, from 2017-05-10 06:17:24)
 
 Copyright (C) 2012-2017 by the following authors:
 - Wladimir J. van der Laan <laanwj@gmail.com>


### PR DESCRIPTION
Found ith the help of libvivhook, ETNAVIV_FEATURES[0-7]_SET,
ETNAVIV_FEATURES[0-7]_CLEAR and gcoHAL_IsFeatureAvailable(..).

Signed-off-by: Christian Gmeiner <christian.gmeiner@gmail.com>