### PR TITLE
etna.h: fix undefined error when compiling with CMD_DEBUG

### DIFF
--- a/attic/etnaviv/etna.h
+++ b/attic/etnaviv/etna.h
@@ -311,7 +311,7 @@ static inline void etna_draw_indexed_primitives(struct etna_ctx *cmdbuf, uint32_
 {
 #ifdef CMD_DEBUG
     printf("draw_primitives_indexed %08x %08x %08x %08x\n",
-            VIV_FE_DRAW_PRIMITIVES_HEADER_OP_DRAW_INDEXED_PRIMITIVES,
+            VIV_FE_DRAW_INDEXED_PRIMITIVES_HEADER_OP_DRAW_INDEXED_PRIMITIVES,
             primitive_type, start, count);
 #endif
     etna_reserve(cmdbuf, 5+1);


### PR DESCRIPTION
`VIV_FE_DRAW_PRIMITIVES_HEADER_OP_DRAW_INDEXED_PRIMITIVES` is not declared anywhere, so this prevents etna.h from being used when CMD_DEBUG is defined.  I was trying to build xf86-video-armada with CMD_DEBUG to understand another issue, and hit the error.