### PR TITLE
update readme: about loongson 7A1000

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ ARM-based:
 MIPS-based:
 - Ingenic JZ4760 has a GC200 (2D only)
 - Ingenic JZ4770 has a GC860: [GCW Zero](http://www.gcw-zero.com)
+- Loongson 7A1000 has a GC1000: [7a1000](http://www.loongson.cn/product/cpu/qp/Loongson7A1000.html)
 
 See also [wikipedia](https://en.wikipedia.org/wiki/Vivante_Corporation).
 


### PR DESCRIPTION
The data sheet of loongson 7a1000 is only Chinese language available, 
and translate it to English is quite difficult for me, sorry about that.
It's a bridge chip that integrate the display controller and vivante gc1000. 
I am trying to get it work with X Server , modesetting driver works but not glamor.