### PR TITLE
TH1520 GC620 related bits

### DIFF
--- a/rnndb/common.xml
+++ b/rnndb/common.xml
@@ -78,6 +78,7 @@ xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
         <value value="0x0520" name="GC520"/>
         <value value="0x0530" name="GC530"/>
         <value value="0x0600" name="GC600"/>
+        <value value="0x0620" name="GC620"/> <!-- 2D graphics -->
         <value value="0x0700" name="GC700"/>
         <value value="0x0800" name="GC800"/> <!-- 3D graphics, 1 core -->
         <value value="0x0860" name="GC860"/>

--- a/rnndb/common.xml
+++ b/rnndb/common.xml
@@ -623,6 +623,9 @@ xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
         <bitfield pos="4" name="TP_REORDER" />
         <bitfield pos="5" name="PE_DEPTH_ONLY_OQFIX" />
     </bitset>
+    <bitset name="chipMinorFeatures12"> <!-- ETNA_GPU_FEATURES_13 -->
+        <bitfield pos="5" name="G2D_DEC400EX" />
+    </bitset>
 
 <domain name="VIVM" brief="GPU memory domain">
 </domain>

--- a/rnndb/state_hi.xml
+++ b/rnndb/state_hi.xml
@@ -530,6 +530,23 @@ xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
         <reg32 offset="0x00570" name="MC_AXI_TOTAL_LATENCY"/> <!-- hasNewCounters -->
         <reg32 offset="0x00574" name="MC_AXI_SAMPLE_COUNT"/> <!-- hasNewCounters -->
     </stripe>
+    <stripe name="DEC400EX" brief="External DEC400 control?">
+        <!-- related to G2D_DEC400EX, galcore comment says "AHBDEC400",
+             the register values specified here are needed to make the MMU work properly -->
+	<reg32 offset="0x00800" name="UNK00800">
+            <doc>
+                Downstream kernel driver writes 0x2010188 in the initialization sequence when
+                DEC400EX feature bit is set. In addition, a quirk for GC620 rev 0x5552 will
+		write 0x10 to this register before soft resetting the GPU, otherwise the MMU
+		won't be properly resetted.
+	    </doc>
+	</reg32>
+	<reg32 offset="0x00808" name="UNK00808">
+	    <doc>
+                Downstream kernel driver writes 0x3fc104 in the initialization sequence.
+	    </doc>
+	</reg32>
+    </stripe>
 </domain>
 
 </database>


### PR DESCRIPTION
This commit is related to my try to get GC620 working on TH1520.

It first adds the obvious model id, and then added the G2D_DEC400EX feature bit from hwdb-converter (should other new feature bits there be added now?), and finally two registered that gets programmed when G2D_DEC400EX feature is there, see [1].

[1] https://github.com/revyos/thead-kernel/blob/lpi4a/drivers/gpu-viv/hal/kernel/arch/gc_hal_kernel_hardware.c#L3004