### PR TITLE
rnndb: Add DISABLE_MODULE_CLOCK_GATING_SH_EU bit

### DIFF
--- a/rnndb/state_hi.xml
+++ b/rnndb/state_hi.xml
@@ -196,6 +196,7 @@ xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
             <bitfield high="5" low="5" name="DISABLE_MODULE_CLOCK_GATING_SE" brief="Disables module level clock gating for SE"/>
             <bitfield high="6" low="6" name="DISABLE_MODULE_CLOCK_GATING_RA" brief="Disables module level clock gating for RA"/>
             <bitfield high="7" low="7" name="DISABLE_MODULE_CLOCK_GATING_TX" brief="Disables module level clock gating for TX"/>
+            <bitfield high="10" low="10" name="DISABLE_MODULE_CLOCK_GATING_SH_EU" brief="Disables module level clock gating for SH EU"/>
             <bitfield high="16" low="16" name="DISABLE_MODULE_CLOCK_GATING_RA_EZ" brief="Disables module level clock gating for RA EZ"/>
             <bitfield high="17" low="17" name="DISABLE_MODULE_CLOCK_GATING_RA_HZ" brief="Disables module level clock gating for RA HZ"/>
             <bitfield high="22" low="22" name="DISABLE_MODULE_CLOCK_GATING_NN" brief="Disables module level clock gating for NN"/>


### PR DESCRIPTION
Taken from [linux-imx lf-6.1.36-2.1.0](https://github.com/nxp-imx/linux-imx/blob/lf-6.1.36-2.1.0/drivers/mxc/gpu-viv/hal/kernel/arch/gc_hal_kernel_hardware.c#L2757), which sets it for the i.MX8MP NPU.