### PR TITLE
Add missing bits for flush MMU

### DIFF
--- a/rnndb/state_blt.xml
+++ b/rnndb/state_blt.xml
@@ -276,6 +276,14 @@ xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
           -->
         <reg32 offset="0x140F4" name="SRC_END" type="VIVM"/>
         <reg32 offset="0x14334" name="DEST_END" type="VIVM"/>
+        <reg32 offset="0x1502E" name="LOCK">
+            <bitfield pos="0" name="ENABLE" brief="Lock BLT engine">
+                <doc>
+                    The BLT engine is need to be locked when flushing the
+                    MMU.
+                </doc>
+            </bitfield>
+        </reg32>
     </stripe>
 
 </domain>

--- a/rnndb/state_hi.xml
+++ b/rnndb/state_hi.xml
@@ -324,6 +324,9 @@ xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
             <bitfield pos="0" name="RESET"/> <!-- Self-clearing GPU reset -->
             <bitfield pos="1" name="NONSEC_ACCESS"/>
         </reg32>
+        <reg32 offset="0x10061" name="FLUSH" value="0XFFFFFF7F">
+            <!-- Value is 0xffffff7f in MMU flush function-->
+        </reg32>
     </stripe>
 
     <stripe name="MC" brief="Memory Controller">


### PR DESCRIPTION
The following data hast been reversed from the `gckHARDWARE_FlushMMU` [1] func. Here is the reworked function in Compiler Explorer [2]

I managed to reduce the function to just commands, the new values are added each in their own commits.
```
/* Flush the memory controller. */
if (mmuVersion == 0) {
	0x08010e04
        0x0000001f
} else {  
        /* LINK to next slot to flush FE FIFO. */
        0x40000006
        0xdeadbabe

        /* Flush MMU cache. */
        0x08010061
        0xffffff7f
        if (bltEngine) {
            /* Blt lock. */
            0x0801502e
            0x00000001

            if (multiCluster) {
                0x080150ce
                0x00000000
            }
        }

        /* Arm the PE-FE Semaphore. */
        0x08010e02
        if (stallFEPrefetch) {
            if (bltEngine) {
                0x30001001
            } else {
                0x30000701
            }
        } else {
            if (bltEngine) {
                0x00001001
            } else {
                0x00000701
            }
        }
        /* STALL FE until PE is done flushing. */
        0x48000000
        if (stallFEPrefetch) {
            if (bltEngine) {
                0x30001001
            } else {
                0x30000701
            }
        } else {
            if (bltEngine) {
                0x00001001
            } else {
                0x00000701
            }
        }

        *buffer++ = stall;

        if (bltEngine) {
            /* Blt unlock. */
            0x0801502e
            0x00000000
        }

        /* LINK to next slot to flush FE FIFO. */
        0x40000000
        0xdeadbabe
}
```

[1]: https://github.com/nxp-imx/linux-imx/blob/lf-6.6.y/drivers/mxc/gpu-viv/hal/kernel/arch/gc_hal_kernel_hardware.c#L4204C1-L4204C21
[2]: https://godbolt.org/z/1vb8aj51b