### PR TITLE
rnndb: fix source stream number field in NFE generic attribute config

### DIFF
--- a/rnndb/state.xml
+++ b/rnndb/state.xml
@@ -479,7 +479,7 @@ xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
                 <bitfield high="3" low="0" name="TYPE" type="FE_DATA_TYPE" brief="Data type"/>
                 <bitfield high="5" low="4" name="ENDIAN" type="ENDIAN_MODE"/>
                 <!-- NONCONSECUTIVE field moved to CONFIG1 for HALTI5 -->
-                <bitfield high="10" low="8" name="STREAM" brief="Source stream number"/>
+                <bitfield high="11" low="8" name="STREAM" brief="Source stream number"/>
                 <bitfield high="13" low="12" name="NUM" brief="Number of elements">
                     <doc>Wraps around (1=1,2=2,3=3,4=0)</doc>
                 </bitfield>


### PR DESCRIPTION
Extend the `STREAM` field in NFE GENERIC_ATTRIB `CONFIG0` to 4 bits, to fix vertex shaders with 9 or more attribute streams.