### PR TITLE
README: Add STM boards supporting etnaviv GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ ARM-based:
 - Freescale i.MX6 DualLite and Solo have a GC880 + GC320
 - Freescale i.MX6 SoloLite has GC320 + GC355 (no 3D)
 - Actions Semiconductor ATM7029 has a GC1000
+- STMicroelectronics STM32MP157 has a GC7000 Nano (MESA3D model GC400)
+- STMicroelectronics STM32MP257 has a GC8000 UL
 
 MIPS-based:
 - Ingenic JZ4760 has a GC200 (2D only)


### PR DESCRIPTION
STM32MP157 supports a [gc400](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/drivers/gpu/drm/etnaviv/etnaviv_hwdb.c?h=v7.0-rc1&id=f56f1579a094573104ffb0e81b623528d992b73c).

STM32MP257 supports a [gc8000](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/drivers/gpu/drm/etnaviv/etnaviv_hwdb.c?h=v7.0-rc1&id=a3fcddaa434712747e136a2a7d02ebd30dc6d76b).

Add those info in the README.